### PR TITLE
Feat#33_1 [Gradient Button] Fixed type

### DIFF
--- a/src/components/GradientButton/GradientButton.jsx
+++ b/src/components/GradientButton/GradientButton.jsx
@@ -2,10 +2,10 @@ import React from 'react';
 
 import * as S from './GradientButton.styled';
 
-const GradientButton = ({ children, gra, width, padding, onClick }) => {
+const GradientButton = ({ children, type, gra, width, padding, onClick }) => {
     return (
         <S.GradientButton
-            type="button"
+            type={type}
             $gra={gra}
             width={width}
             $padding={padding}

--- a/src/components/GradientButton/GradientButton.styled.jsx
+++ b/src/components/GradientButton/GradientButton.styled.jsx
@@ -1,6 +1,8 @@
 import { styled, css } from 'styled-components';
 
-export const GradientButton = styled.button`
+export const GradientButton = styled.button.attrs(props => ({
+    type: props.type || 'button',
+}))`
     width: ${props => props.width};
     border: 1px solid ${props => props.theme.main};
     border-radius: 12px;


### PR DESCRIPTION
## 작업사항
기존 gradient button의 type은 button으로 submit기능을 수행할 수 없어서 변경했습니다.

default 값은 button이니 type설정을 안하셔도 되고
submit 기능을 수행해야 하는 버튼인 경우에만 prop으로 type={'submit'} 을 추가해주시면 됩니다. :)

