### PR TITLE
Feat#62_1 [팔로워 화면] 팔로워 UI 기본, 팔로워 API 연동

### DIFF
--- a/src/pages/FollowFollowingList/FollowFollowingList.jsx
+++ b/src/pages/FollowFollowingList/FollowFollowingList.jsx
@@ -1,8 +1,0 @@
-import React from 'react';
-import * as S from './Board.styled';
-
-const FollowFollowingList = () => {
-    return <div>FollowFollowingList</div>;
-};
-
-export default FollowFollowingList;

--- a/src/pages/FollowFollowingList/FollowFollowingList.styled.jsx
+++ b/src/pages/FollowFollowingList/FollowFollowingList.styled.jsx
@@ -1,1 +1,0 @@
-import styled from 'styled-components';

--- a/src/pages/FollowFollowingList/FollowerList.jsx
+++ b/src/pages/FollowFollowingList/FollowerList.jsx
@@ -1,0 +1,43 @@
+import React, { useEffect, useState } from 'react';
+import * as S from './FollowerList.styled';
+import GradientButton from '../../components/GradientButton/GradientButton';
+import { followService } from '../../service/follow_service';
+
+const FollowerList = () => {
+    const [followerData, setFollowerData] = useState(null);
+
+    useEffect(() => {
+        followService()
+            .then(data => {
+                setFollowerData(data);
+                // console.log('follower:', data);
+            })
+            .catch(error => {
+                console.error('API 요청 중 오류 발생: ', error);
+            });
+    }, []);
+
+    console.log('follower:', followerData);
+
+    return (
+        <>
+            <S.FollowerHeader>
+                <button>
+                    <S.Backwardicon />
+                </button>
+                <h2>Follwer</h2>
+            </S.FollowerHeader>
+            <S.FollwerContainer>
+                <S.FollwerList>
+                    <S.FollowerInfo>
+                        <img src="" className="follower-img" />
+                        <div>followerID</div>
+                    </S.FollowerInfo>
+                    <GradientButton padding={'10px'}>follow</GradientButton>
+                </S.FollwerList>
+            </S.FollwerContainer>
+        </>
+    );
+};
+
+export default FollowerList;

--- a/src/pages/FollowFollowingList/FollowerList.styled.jsx
+++ b/src/pages/FollowFollowingList/FollowerList.styled.jsx
@@ -1,0 +1,45 @@
+import styled from 'styled-components';
+import { ReactComponent as Backward } from '../../assets/images/Backward.svg';
+
+export const Backwardicon = styled(Backward)``;
+
+export const FollowerHeader = styled.header`
+    display: flex;
+    width: 310px;
+    height: 70px;
+    padding-top: 20px;
+    margin: 0 25px;
+
+    font-size: 24px;
+    align-items: center;
+`;
+
+export const FollwerContainer = styled.ul`
+    width: 100%;
+    overflow-y: auto;
+`;
+
+export const FollwerList = styled.li`
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+    padding: 20px 5px;
+    border: 1px ${({ theme }) => theme.border} dashed;
+    border-left: none;
+    border-right: none;
+    border-top: none;
+    overflow-y: auto;
+    .follower-img {
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        margin-right: 8px;
+        /* background-color: red; */
+    }
+`;
+
+export const FollowerInfo = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 20px;
+`;

--- a/src/service/follow_service.jsx
+++ b/src/service/follow_service.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+const baseURL = 'https://api.mandarin.weniv.co.kr/';
+const token = sessionStorage.getItem('tempToken');
+const myAccountName = sessionStorage.getItem('tempAccountName');
+
+export const followService = async () => {
+    const reqURL = `${baseURL}profile/${myAccountName}/following`;
+
+    console.log(myAccountName);
+    try {
+        const response = await fetch(reqURL, {
+            method: 'GET',
+            headers: {
+                Authorization: `Bearer ${token}`,
+                'Content-type': 'application/json',
+            },
+        });
+        const result = await response.json();
+        console.log(result);
+        return result;
+    } catch (error) {
+        console.error(error);
+    }
+};


### PR DESCRIPTION
##작업사항
팔로워 UI 레이아웃 완성, 팔로워 목록 API 연결하여 데이터 가져오기

###코멘트(를받고싶다면 작성)
- [x] 팔로워 데이터가 현재 빈 목록이지만 연결이 잘 되었는지 확인
- [x] UI 기본적인 틀을 우선 완성했는데 추가적으로 필요한 점

##기타
팔로우/언팔로우 토글 버튼 설정은 이어서 진행할 예정입니다.