### PR TITLE
Feat#82_1 [페이지 이동 & 마커 구현] 페이지 간 이동 구현 및 마커 구현

### DIFF
--- a/src/components/Ballon/Ballon.jsx
+++ b/src/components/Ballon/Ballon.jsx
@@ -3,10 +3,9 @@ import { useNavigate } from 'react-router-dom';
 
 import * as S from './Ballon.styled';
 
-const Ballon = ({ productItem, deleteProduct }) => {
+const Ballon = ({ productItem, deleteProduct, isEditing }) => {
     // 내 글이 아니고, 수정중이 아니라면 삭제하기 안보이게
     const navigate = useNavigate();
-
     const editProduct = () => {
         navigate(`/newboard/${productItem.detail.id}`, {
             state: { editProductItem: productItem },
@@ -52,17 +51,25 @@ const Ballon = ({ productItem, deleteProduct }) => {
                 style={{ left: calcArrowLeft(productItem.marker.x) }}
             />
             <S.Product>
-                <div onClick={editProduct}>
+                <div
+                    onClick={() => {
+                        if (isEditing) {
+                            editProduct();
+                        }
+                    }}
+                >
                     {productItem.detail.productName}
                 </div>
                 <div> {productItem.detail.price}</div>
             </S.Product>
-            <S.DeletItemButton
-                type="button"
-                onClick={() => deleteProduct(productItem.detail.id)}
-            >
-                <S.TrashIcon />
-            </S.DeletItemButton>
+            {isEditing && (
+                <S.DeletItemButton
+                    type="button"
+                    onClick={() => deleteProduct(productItem.detail.id)}
+                >
+                    <S.TrashIcon />
+                </S.DeletItemButton>
+            )}
         </S.Ballon>
     );
 };

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import * as S from './Header.styled';
 import { useSelector } from 'react-redux';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 
 const Header = () => {
     const navigate = useNavigate();
@@ -18,6 +18,10 @@ const Header = () => {
     const isChat = location.pathname.includes('/chat');
     const isMyProfile = location.pathname.includes('/profile');
     const isUserProfile = location.pathname.includes('/userProfile');
+
+    // useEffect(() => {
+    //     console.log(currentPage);
+    // });
 
     return (
         <>
@@ -42,11 +46,13 @@ const Header = () => {
                     )}
                     {currentPage.type === 'user' && (
                         <S.UserInfo>
-                            <img
-                                src={currentPage.value}
-                                alt=""
-                                className="user-img"
-                            />
+                            <Link to={`userprofile/${currentPage.accountname}`}>
+                                <img
+                                    src={currentPage.value}
+                                    alt=""
+                                    className="user-img"
+                                />
+                            </Link>
                             <h2>{currentPage.username}</h2>
                         </S.UserInfo>
                     )}

--- a/src/components/Marker/Marker.jsx
+++ b/src/components/Marker/Marker.jsx
@@ -6,7 +6,13 @@ import * as S from './Marker.styled';
 import markerImg from '../../assets/images/Marker.svg';
 
 export const Marker = React.forwardRef((props, markerRef) => {
-    const { onMouseDown, markerLocation, productItem, deleteProduct } = props;
+    const {
+        onMouseDown,
+        markerLocation,
+        productItem,
+        deleteProduct,
+        isEditing,
+    } = props;
 
     return (
         <S.MarkerContainer>
@@ -25,6 +31,7 @@ export const Marker = React.forwardRef((props, markerRef) => {
                 <Ballon
                     productItem={productItem}
                     deleteProduct={deleteProduct}
+                    isEditing={isEditing}
                 />
             )}
         </S.MarkerContainer>

--- a/src/hooks/usePageHandler.js
+++ b/src/hooks/usePageHandler.js
@@ -3,14 +3,19 @@ import { useDispatch } from 'react-redux';
 import { setPageTitle } from '../features/pageTitle/pageTitleSlice';
 import { useEffect } from 'react';
 
-const usePageHandler = (type, title, username) => {
+const usePageHandler = (type, title, username, accountname) => {
     const dispatch = useDispatch();
 
     useEffect(() => {
         dispatch(
-            setPageTitle({ type: type, value: title, username: username }),
+            setPageTitle({
+                type: type,
+                value: title,
+                username: username,
+                accountname: accountname,
+            }),
         );
-    }, [dispatch, title, username]);
+    }, [dispatch, title, username, accountname]);
 };
 
 export default usePageHandler;

--- a/src/pages/DetailPost/DetailPost.jsx
+++ b/src/pages/DetailPost/DetailPost.jsx
@@ -151,7 +151,7 @@ const DetailPost = deleteItem => {
                                                     top: item.marker.y,
                                                 }}
                                                 productItem={item}
-                                                deleteProduct={deleteItem}
+                                                isEditing={false}
                                             />
                                         ),
                                     )}

--- a/src/pages/DetailPost/DetailPost.jsx
+++ b/src/pages/DetailPost/DetailPost.jsx
@@ -7,7 +7,7 @@ import {
     postComment,
     deleteCommentAPI,
 } from '../../service/comment_service';
-import { useNavigate, useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router-dom';
 import { Marker } from '../../components/Marker/Marker';
 
 import BottomSheet from '../../components/BottomSheet/BottomSheet';
@@ -56,6 +56,7 @@ const DetailPost = deleteItem => {
             //     }),
             // );
             setPostData(postResult.post);
+            // console.log(postResult);
         } catch (error) {
             console.error('error');
         }
@@ -246,14 +247,6 @@ const DetailPost = deleteItem => {
                     deleteFn={e => deleteComment(e)}
                 />
             </S.DetailPostCotainer>
-            <S.FollowBtnBox>
-                <GradientButton
-                    children={'팔로우'}
-                    gra={true}
-                    width={'70px'}
-                    padding={'10px'}
-                />
-            </S.FollowBtnBox>
         </>
     );
 };

--- a/src/pages/DetailPost/DetailPost.jsx
+++ b/src/pages/DetailPost/DetailPost.jsx
@@ -13,6 +13,7 @@ import { Marker } from '../../components/Marker/Marker';
 import BottomSheet from '../../components/BottomSheet/BottomSheet';
 
 import usePageHandler from '../../hooks/usePageHandler';
+import Ballon from '../../components/Ballon/Ballon';
 
 const DetailPost = deleteItem => {
     const [postData, setPostData] = useState(null);
@@ -29,34 +30,11 @@ const DetailPost = deleteItem => {
     const postApi = async (id, token) => {
         try {
             const postResult = await fetchPosts(id, token);
-            const dataObject = JSON.parse(postResult.post.content);
 
             setPostContent(JSON.parse(postResult.post.content));
 
-            // setMakerData(
-            //     dataObject.deskoration.map(item => {
-            //         const {
-            //             category,
-            //             productName,
-            //             price,
-            //             store,
-            //             link,
-            //             id,
-            //             location,
-            //         } = item;
-            //         return {
-            //             category,
-            //             productName,
-            //             price,
-            //             store,
-            //             link,
-            //             id,
-            //             location,
-            //         };
-            //     }),
-            // );
             setPostData(postResult.post);
-            // console.log(postResult);
+            console.log(JSON.parse(postResult.post.content));
         } catch (error) {
             console.error('error');
         }
@@ -110,7 +88,12 @@ const DetailPost = deleteItem => {
         setIsCommentBottomSheet(!isCommentBottomSheet);
     };
 
-    usePageHandler('user', postData?.author.image, postData?.author.username);
+    usePageHandler(
+        'user',
+        postData?.author.image,
+        postData?.author.username,
+        postData?.author.accountname,
+    );
 
     const editPost = e => {
         e.stopPropagation();
@@ -151,21 +134,28 @@ const DetailPost = deleteItem => {
                     {postData && ( // null이 아닌 경우에만 렌더링
                         <>
                             <S.ContentSection>
-                                <img
-                                    src={postData.image}
-                                    alt="데스크 셋업 이미지"
-                                />
-                                {markerData.map((key, index) => (
-                                    <Marker
-                                        key={index}
-                                        markerLocation={{
-                                            left: key.location.x,
-                                            top: key.location.y,
-                                        }}
-                                        productItem={key}
-                                        deleteItem={deleteItem}
+                                <div
+                                    className="post"
+                                    style={{ position: 'relative' }}
+                                >
+                                    <img
+                                        src={postData?.image}
+                                        alt="데스크 셋업 이미지"
                                     />
-                                ))}
+                                    {postContent?.deskoration.productItems?.map(
+                                        (item, index) => (
+                                            <Marker
+                                                key={index}
+                                                markerLocation={{
+                                                    left: item.marker.x,
+                                                    top: item.marker.y,
+                                                }}
+                                                productItem={item}
+                                                deleteProduct={deleteItem}
+                                            />
+                                        ),
+                                    )}
+                                </div>
 
                                 <S.ContentButtonBox>
                                     <div>

--- a/src/pages/Home/Article.jsx
+++ b/src/pages/Home/Article.jsx
@@ -8,15 +8,14 @@ const Article = () => {
     const [articles, setArticles] = useState([]);
     const [loading, setLoading] = useState(false);
     const sectionRef = useRef(null); // S.Section에 대한 참조 생성
-
     const token = sessionStorage.getItem('tempToken');
     const tempAccountName = sessionStorage.getItem('tempAccountName');
 
-    const tempApi = async (accountName, token) => {
+    const tempApi = async token => {
         try {
-            const result = await GetMyPost(accountName, token);
-            console.log('API보기2: ', result);
-            const deskoration = result.filter(post =>
+            const result = await GetAllPost(token);
+            // console.log('API보기2: ', result.posts);
+            const deskoration = result.posts.filter(post =>
                 post.content?.includes('"deskoration"'),
             );
             console.log('deskoration: ', deskoration);
@@ -28,7 +27,7 @@ const Article = () => {
 
     console.log('articles', articles);
     useEffect(() => {
-        const desk_result = tempApi(tempAccountName, token);
+        const desk_result = tempApi(token);
     }, []);
 
     const postImage = articles.map(item => item.image);
@@ -64,7 +63,7 @@ const Article = () => {
         <>
             <S.Section ref={sectionRef}>
                 {articles.map(article => (
-                    <Link key={article.id} to={`/detailpost/${article.id}`}>
+                    <Link key={article.id} to={`/detailpost/${article._id}`}>
                         <S.Article src={article.image}></S.Article>
                     </Link>
                 ))}

--- a/src/pages/NewBoard/PostUploadForm.jsx
+++ b/src/pages/NewBoard/PostUploadForm.jsx
@@ -259,6 +259,7 @@ const PostUploadForm = ({
                                     }}
                                     productItem={item}
                                     deleteProduct={deleteProduct}
+                                    isEditing={true}
                                 />
                             ))
                         )}

--- a/src/pages/Profile/Profile.jsx
+++ b/src/pages/Profile/Profile.jsx
@@ -54,12 +54,6 @@ const Profile = () => {
 
     return (
         <>
-            <S.ProfileHeader>
-                <button>
-                    <S.Backwardicon onClick={handleGoBack} />
-                </button>
-                <h2>My profile</h2>
-            </S.ProfileHeader>
             <S.ProfileContainer>
                 <S.UserInfo>
                     <img src={profileData?.image} alt="" className="user-img" />

--- a/src/pages/Profile/Profile.jsx
+++ b/src/pages/Profile/Profile.jsx
@@ -4,22 +4,29 @@ import Footer from '../../components/Footer/Footer';
 import GradientButton from '../../components/GradientButton/GradientButton';
 import Article from '../Home/Article';
 import { GetMyProfile } from '../../service/profile_service';
-import { fetchPosts } from '../../service/board_service';
-import { Link } from 'react-router-dom';
-import usePageHandler from '../../hooks/usePageHandler';
+import { Link, useNavigate } from 'react-router-dom';
+import { GetMyPost } from '../../service/post_service';
 
 const Profile = () => {
     const [profileData, setProfileData] = useState(null);
     const [userPost, setUserPost] = useState(null);
     const [expandedContent, setExpandedContent] = useState(false);
 
-    const myAccountName = sessionStorage.getItem('tempAccountName');
+    const token = sessionStorage.getItem('tempToken');
+    const tempAccountName = sessionStorage.getItem('tempAccountName');
+    const myId = sessionStorage.getItem('tempID');
 
-    usePageHandler('text', '나의 프로필');
+    const navigate = useNavigate();
+
+    const handleGoBack = () => {
+        navigate(-1); // Use navigate to go back to the previous page
+    };
+
+    // usePageHandler('text', '나의 프로필');
 
     useEffect(() => {
         // API 호출해서 데이터 받아오기
-        GetMyProfile()
+        GetMyProfile(token)
             .then(data => {
                 setProfileData(data.user);
                 console.log(data.user);
@@ -27,10 +34,10 @@ const Profile = () => {
             .catch(error => {
                 console.error('API 요청 중 오류 발생: ', error);
             });
-        fetchPosts(myAccountName)
+        GetMyPost(tempAccountName, token)
             .then(data => {
-                setUserPost(data.post);
-                console.log(data.post);
+                setUserPost(data);
+                console.log(data);
             })
             .catch(error => {
                 console.error('API 요청 중 오류 발생: ', error);
@@ -47,17 +54,23 @@ const Profile = () => {
 
     return (
         <>
+            <S.ProfileHeader>
+                <button>
+                    <S.Backwardicon onClick={handleGoBack} />
+                </button>
+                <h2>My profile</h2>
+            </S.ProfileHeader>
             <S.ProfileContainer>
                 <S.UserInfo>
-                    <img src={profileData.image} alt="" className="user-img" />
+                    <img src={profileData?.image} alt="" className="user-img" />
 
                     <div className="user-introduce">
-                        <p className="user-name">{profileData.accountname}</p>
+                        <p className="user-name">{profileData?.accountname}</p>
                         <p className="user-info">
                             {expandedContent
-                                ? profileData.intro
-                                : profileData.intro.slice(0, 53)}
-                            {profileData.intro?.length > 30 && (
+                                ? profileData?.intro
+                                : profileData?.intro.slice(0, 53)}
+                            {profileData?.intro?.length > 30 && (
                                 <button onClick={toggleExpandedContent}>
                                     {expandedContent ? '접기' : '더보기'}
                                 </button>
@@ -80,20 +93,22 @@ const Profile = () => {
                     </button>
                     <Link to="/follow-following-list">
                         <button className="user-follow">
-                            <p>{profileData.followerCount}</p>
+                            <p>{profileData?.followerCount}</p>
                             <p>팔로우</p>
                         </button>
                     </Link>
                     <Link to="/follow-following-list">
                         <button className="user-following">
-                            <p>{profileData.followingCount}</p>
+                            <p>{profileData?.followingCount}</p>
                             <p>팔로잉</p>
                         </button>
                     </Link>
                 </S.UserDataList>
                 <S.UserPostings>
                     {userPost?.map((post, index) => (
-                        <img key={index} src={post.image} alt="게시물 목록" />
+                        <Link key={post.id} to={`/detailpost/${post.id}`}>
+                            <img src={post.image} alt="게시물 목록" />
+                        </Link>
                     ))}
                 </S.UserPostings>
             </S.ProfileContainer>

--- a/src/pages/Profile/Profile.jsx
+++ b/src/pages/Profile/Profile.jsx
@@ -22,7 +22,7 @@ const Profile = () => {
         navigate(-1); // Use navigate to go back to the previous page
     };
 
-    usePageHandler('text', '나의 프로필');
+    // usePageHandler('text', '나의 프로필');
 
     useEffect(() => {
         // API 호출해서 데이터 받아오기

--- a/src/pages/Profile/Profile.jsx
+++ b/src/pages/Profile/Profile.jsx
@@ -22,7 +22,7 @@ const Profile = () => {
         navigate(-1); // Use navigate to go back to the previous page
     };
 
-    // usePageHandler('text', '나의 프로필');
+    usePageHandler('text', '나의 프로필');
 
     useEffect(() => {
         // API 호출해서 데이터 받아오기

--- a/src/pages/Profile/Profile.styled.jsx
+++ b/src/pages/Profile/Profile.styled.jsx
@@ -102,24 +102,37 @@ export const UserDataList = styled.div`
 `;
 
 export const UserPostings = styled.div`
-    margin-top: 10px;
-    display: flex;
     flex-wrap: wrap;
     justify-content: space-between;
-    width: auto;
-    height: auto;
     color: ${({ theme }) => theme.mainFont};
     overflow-y: hidden;
 
     img {
-        width: 50%;
-        height: 50%;
+        width: 50%; /* Fill the available width in each column */
         box-sizing: border-box;
         transition: border 0.1s ease;
         &:hover {
             border: 3px solid ${({ theme }) => theme.main};
         }
         border: 3px solid white;
+        border-radius: 10px;
+    }
+
+    &::-webkit-scrollbar {
+        width: 7px;
+    }
+
+    &::-webkit-scrollbar-thumb {
+        background-color: #888;
+        border-radius: 10px;
+    }
+
+    &::-webkit-scrollbar-thumb:hover {
+        background-color: #555;
+    }
+
+    &::-webkit-scrollbar-track {
+        background-color: #f5f5f5;
         border-radius: 10px;
     }
 `;

--- a/src/pages/Profile/UserProfile.jsx
+++ b/src/pages/Profile/UserProfile.jsx
@@ -18,7 +18,7 @@ const UserProfile = () => {
         navigate(-1); // Use navigate to go back to the previous page
     };
 
-    // usePageHandler('text', profileData?.accountname);
+    usePageHandler('text', profileData?.accountname);
 
     useEffect(() => {
         // API 호출해서 데이터 받아오기

--- a/src/pages/Profile/UserProfile.jsx
+++ b/src/pages/Profile/UserProfile.jsx
@@ -2,30 +2,36 @@ import React, { useEffect, useState } from 'react';
 import * as S from './UserProfile.styled';
 import GradientButton from '../../components/GradientButton/GradientButton';
 import { GetUserProfile } from '../../service/profile_service';
-import { fetchPosts } from '../../service/board_service';
-import { Link } from 'react-router-dom';
-import usePageHandler from '../../hooks/usePageHandler';
+import { GetMyPost, fetchPosts } from '../../service/post_service';
+import { Link, useNavigate, useParams } from 'react-router-dom';
 
 const UserProfile = () => {
     const [profileData, setProfileData] = useState(null);
     const [userPost, setUserPost] = useState(null);
     const [expandedContent, setExpandedContent] = useState(false);
+    const { username } = useParams(); //선택한 게시물 아이디 값
+    const token = sessionStorage.getItem('tempToken');
 
-    usePageHandler('text', profileData?.accountname);
+    const navigate = useNavigate();
+
+    const handleGoBack = () => {
+        navigate(-1); // Use navigate to go back to the previous page
+    };
+
+    // usePageHandler('text', profileData?.accountname);
 
     useEffect(() => {
         // API 호출해서 데이터 받아오기
-        GetUserProfile()
+        GetUserProfile(username, token)
             .then(data => {
                 setProfileData(data.profile);
-                // setotherAccountname(data.profile.accountname);
-                // console.log(data.profile);
+                console.log(data.profile);
                 return data.profile.accountname;
             })
             .then(temp => {
-                fetchPosts(temp).then(data => {
-                    setUserPost(data.post);
-                    // console.log(data.post);
+                GetMyPost(temp, token).then(data => {
+                    setUserPost(data);
+                    console.log(data);
                 });
             })
             .catch(error => {
@@ -43,16 +49,22 @@ const UserProfile = () => {
 
     return (
         <>
+            <S.ProfileHeader>
+                <button>
+                    <S.Backwardicon onClick={handleGoBack} />
+                </button>
+                <h2>{profileData?.accountname}</h2>
+            </S.ProfileHeader>
             <S.ProfileContainer>
                 <S.UserInfo>
-                    <img src={profileData.image} alt="" className="user-img" />
+                    <img src={profileData?.image} alt="" className="user-img" />
 
                     <div className="user-introduce">
-                        <p className="user-name">{profileData.accountname}</p>
+                        <p className="user-name">{profileData?.accountname}</p>
                         <p className="user-info">
                             {expandedContent
                                 ? profileData.intro
-                                : profileData.intro.slice(0, 53)}
+                                : profileData?.intro?.slice(0, 53)}
                             {profileData.intro?.length > 30 && (
                                 <button onClick={toggleExpandedContent}>
                                     {expandedContent ? '접기' : '더보기'}
@@ -86,20 +98,22 @@ const UserProfile = () => {
                     </button>
                     <Link to="/follow-following-list">
                         <button className="user-follow">
-                            <p>{profileData.followerCount}</p>
+                            <p>{profileData?.followerCount}</p>
                             <p>팔로우</p>
                         </button>
                     </Link>
                     <Link to="/follow-following-list">
                         <button className="user-following">
-                            <p>{profileData.followingCount}</p>
+                            <p>{profileData?.followingCount}</p>
                             <p>팔로잉</p>
                         </button>
                     </Link>
                 </S.UserDataList>
                 <S.UserPostings>
                     {userPost?.map((post, index) => (
-                        <img key={index} src={post.image} alt="게시물 목록" />
+                        <Link key={post.id} to={`/detailpost/${post.id}`}>
+                            <img src={post.image} alt="게시물 목록" />
+                        </Link>
                     ))}
                 </S.UserPostings>
             </S.ProfileContainer>

--- a/src/pages/Profile/UserProfile.jsx
+++ b/src/pages/Profile/UserProfile.jsx
@@ -49,12 +49,6 @@ const UserProfile = () => {
 
     return (
         <>
-            <S.ProfileHeader>
-                <button>
-                    <S.Backwardicon onClick={handleGoBack} />
-                </button>
-                <h2>{profileData?.accountname}</h2>
-            </S.ProfileHeader>
             <S.ProfileContainer>
                 <S.UserInfo>
                     <img src={profileData?.image} alt="" className="user-img" />

--- a/src/pages/Profile/UserProfile.jsx
+++ b/src/pages/Profile/UserProfile.jsx
@@ -18,7 +18,7 @@ const UserProfile = () => {
         navigate(-1); // Use navigate to go back to the previous page
     };
 
-    usePageHandler('text', profileData?.accountname);
+    // usePageHandler('text', profileData?.accountname);
 
     useEffect(() => {
         // API 호출해서 데이터 받아오기

--- a/src/pages/Profile/UserProfile.styled.jsx
+++ b/src/pages/Profile/UserProfile.styled.jsx
@@ -105,18 +105,13 @@ export const UserDataList = styled.div`
 `;
 
 export const UserPostings = styled.div`
-    margin-top: 10px;
-    display: flex;
     flex-wrap: wrap;
     justify-content: space-between;
-    width: auto;
-    height: auto;
     color: ${({ theme }) => theme.mainFont};
     overflow-y: hidden;
 
     img {
         width: 50%;
-        height: 50%;
         box-sizing: border-box;
         transition: border 0.1s ease;
         &:hover {

--- a/src/router/Router.jsx
+++ b/src/router/Router.jsx
@@ -2,7 +2,6 @@ import { React, lazy, Suspense } from 'react';
 
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 
-
 const HomePage = lazy(() => import('../pages/Home/Home'));
 const NewBoardPage = lazy(() => import('../pages/NewBoard/NewBoard'));
 const LoginPage = lazy(() => import('../pages/User/Login'));
@@ -52,7 +51,7 @@ const Router = () => {
                         <Route path={'/chat'} element={<ChatListPage />} />
                         <Route path={'/profile'} element={<ProfilePage />} />
                         <Route
-                            path={'/userProfile'}
+                            path={'/userProfile/:username'}
                             element={<UserProfilePage />}
                         />
                         <Route path={'/newboard'} element={<NewBoardPage />} />
@@ -70,7 +69,6 @@ const Router = () => {
                             element={<ChatRoomPage />}
                         />
                     </Route>
-
 
                     <Route element={<NoFooterLayoutPage />}>
                         <Route

--- a/src/service/profile_service.jsx
+++ b/src/service/profile_service.jsx
@@ -1,10 +1,8 @@
 const baseURL = 'https://api.mandarin.weniv.co.kr/';
-const token = sessionStorage.getItem('tempToken');
 const myAccountName = sessionStorage.getItem('tempAccountName');
-const userAccountName = 'hothot';
 
-export const GetUserProfile = async () => {
-    const reqURL = `${baseURL}profile/${userAccountName}`;
+export const GetUserProfile = async (username, token) => {
+    const reqURL = `${baseURL}profile/${username}`;
 
     try {
         const response = await fetch(reqURL, {
@@ -22,7 +20,7 @@ export const GetUserProfile = async () => {
     }
 };
 
-export const GetMyProfile = async () => {
+export const GetMyProfile = async token => {
     const reqURL = `${baseURL}user/myinfo`;
 
     try {


### PR DESCRIPTION

## 작업사항
1. 상대 프로필 사진 클릭시 해당 유저 프로필페이지 이동
2. 프로필 게시물 클릭 시 게시물 상세보기 페이지로 이동
3. 게시물 상세보기 마커 구현 (수정 안되게, 삭제 안되게)

### 코멘트
- [x] 페이지 별로 기능들이 잘 적용 되고, 이동이 되는지 확인해주세요(프로필 사진 클릭 -> 상대 프로필 페이지 이동/ 프로필 페이지 게시글 클릭 -> 게시글 상세보기 페이지 이동 등)
- [x] 게시글 상세보기에서 마커를 볼때 수정과 삭제가 안되는지, 업로드 할때 마커에는 수정과 삭제가 잘 되는지 확인해주세요
