### PR TITLE
Feat#92_1 [splash] splash와 홈화면 로딩 추가

### DIFF
--- a/src/pages/Home/Article.jsx
+++ b/src/pages/Home/Article.jsx
@@ -1,31 +1,15 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { Link } from 'react-router-dom';
 import * as S from './Article.styled';
-import { GetAllPost } from '../../service/post_service';
+import DetailPost from '../DetailPost/DetailPost';
+import { GetMyPost } from '../../service/post_service';
 
-const Article = () => {
-    const [articles, setArticles] = useState([]);
+const Article = ({ articles, setArticles }) => {
     const [loading, setLoading] = useState(false);
-    const sectionRef = useRef(null);
-    const token = sessionStorage.getItem('tempToken');
+    const sectionRef = useRef(null); // S.Section에 대한 참조 생성
+    const tempAccountName = sessionStorage.getItem('tempAccountName');
 
-    const fetchAllPost = async token => {
-        try {
-            const result = await GetAllPost(token);
-            const deskoration = result.posts.filter(post =>
-                post.content?.includes('"deskoration"'),
-            );
-            console.log('deskoration: ', deskoration);
-            setArticles(deskoration);
-        } catch (error) {
-            console.error('error');
-        }
-    };
-
-    console.log('articles', articles);
-    useEffect(() => {
-        fetchAllPost(token);
-    }, []);
+    const postImage = articles.map(item => item.image);
 
     useEffect(() => {
         const handleScroll = () => {

--- a/src/pages/Home/Home.jsx
+++ b/src/pages/Home/Home.jsx
@@ -38,7 +38,7 @@ const Home = () => {
     usePageHandler('image', logoImg);
     return (
         <>
-            {isReady ? (
+            {!isReady ? (
                 <CommonLoading />
             ) : (
                 <>

--- a/src/pages/Home/Home.jsx
+++ b/src/pages/Home/Home.jsx
@@ -1,16 +1,25 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import * as S from './Home.styled';
 import logoImg from '../../assets/images/Logo.svg';
 import Article from './Article';
 import Slide from './Slide';
+import FirstConnectLoading from '../Loading/FirstConnectLoading';
 import usePageHandler from '../../hooks/usePageHandler';
 
 const Home = () => {
+    const [isLoading, setIsLoading] = useState(false);
+
     usePageHandler('image', logoImg);
     return (
         <>
-            <Slide />
-            <Article />
+            {isLoading ? (
+                <FirstConnectLoading />
+            ) : (
+                <>
+                    <Slide />
+                    <Article />
+                </>
+            )}
         </>
     );
 };

--- a/src/pages/Home/Home.jsx
+++ b/src/pages/Home/Home.jsx
@@ -3,21 +3,47 @@ import * as S from './Home.styled';
 import logoImg from '../../assets/images/Logo.svg';
 import Article from './Article';
 import Slide from './Slide';
-import FirstConnectLoading from '../Loading/FirstConnectLoading';
 import usePageHandler from '../../hooks/usePageHandler';
+import { GetAllPost } from '../../service/post_service';
+import CommonLoading from '../Loading/CommonLoading';
 
 const Home = () => {
-    const [isLoading, setIsLoading] = useState(false);
+    const [articles, setArticles] = useState([]);
+    const [isReady, setIsReady] = useState(false);
+    const token = sessionStorage.getItem('tempToken');
+
+    console.log('articles', articles);
+
+    const tempApi = async token => {
+        try {
+            const result = await GetAllPost(token);
+            // console.log('API보기2: ', result.posts);
+            const deskoration = result.posts.filter(post =>
+                post.content?.includes('"deskoration"'),
+            );
+            console.log('deskoration: ', deskoration);
+            setArticles(deskoration); // Set the state with articles containing images
+            setIsReady(true);
+        } catch (error) {
+            console.error('error');
+        }
+    };
+
+    useEffect(() => {
+        const desk_result = tempApi(token);
+    }, []);
+
+    console.log(isReady);
 
     usePageHandler('image', logoImg);
     return (
         <>
-            {isLoading ? (
-                <FirstConnectLoading />
+            {isReady ? (
+                <CommonLoading />
             ) : (
                 <>
                     <Slide />
-                    <Article />
+                    <Article articles={articles} setArticles={setArticles} />
                 </>
             )}
         </>

--- a/src/pages/Loading/CommonLoading.jsx
+++ b/src/pages/Loading/CommonLoading.jsx
@@ -11,7 +11,7 @@ const CommonLoading = () => {
 
             setTimeout(() => {
                 setToggleColor(false);
-            }, 2500);
+            }, 2000);
         };
         const intervalId = setInterval(textAnimationLoop, 5000);
         textAnimationLoop();

--- a/src/pages/Loading/CommonLoading.jsx
+++ b/src/pages/Loading/CommonLoading.jsx
@@ -1,11 +1,35 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import * as S from './CommonLoading.styled';
 
 const CommonLoading = () => {
+    const text = 'Deskoration';
+    const [toggleColor, setToggleColor] = useState(false);
+
+    useEffect(() => {
+        const textAnimationLoop = () => {
+            setToggleColor(true);
+
+            setTimeout(() => {
+                setToggleColor(false);
+            }, 2500);
+        };
+        const intervalId = setInterval(textAnimationLoop, 5000);
+        textAnimationLoop();
+        return () => clearInterval(intervalId);
+    }, []);
+
     return (
-        <>
-            <S.Loading></S.Loading>
-        </>
+        <S.TitleBox>
+            {text.split('').map((char, index) => (
+                <S.CharSpan
+                    key={index}
+                    $toggleColor={toggleColor}
+                    $delay={0.1 * index}
+                >
+                    {char}
+                </S.CharSpan>
+            ))}
+        </S.TitleBox>
     );
 };
 

--- a/src/pages/Loading/CommonLoading.styled.jsx
+++ b/src/pages/Loading/CommonLoading.styled.jsx
@@ -3,6 +3,10 @@ import styled, { css } from 'styled-components';
 export const TitleBox = styled.h1`
     font-size: 24px;
     font-weight: 700;
+    height: calc(100vh - 145px);
+    display: flex;
+    justify-content: center;
+    align-items: center;
 `;
 
 export const CharSpan = styled.span`
@@ -14,7 +18,7 @@ export const CharSpan = styled.span`
             : css`
                   color: ${props => props.theme.main};
               `}
-    transition: color 1.5s;
+    transition: color 0.8s;
     ${props =>
         props.$delay &&
         css`

--- a/src/pages/Loading/CommonLoading.styled.jsx
+++ b/src/pages/Loading/CommonLoading.styled.jsx
@@ -1,25 +1,23 @@
-import styled, { keyframes } from 'styled-components';
+import styled, { css } from 'styled-components';
 
-const baseLineHeight = '30px';
-const grayRGB = '170, 170, 170';
-const alphaValue = 0.2;
-const offGray = `rgba(${grayRGB}, ${alphaValue})`;
-const spinDuration = '1s';
-
-const spin = keyframes`
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+export const TitleBox = styled.h1`
+    font-size: 24px;
+    font-weight: 700;
 `;
 
-export const Loading = styled.div`
-    border-radius: 50%;
-    width: ${baseLineHeight};
-    height: ${baseLineHeight};
-    border: 0.25rem solid ${offGray};
-    border-top-color: rgb(${grayRGB}); // rgb() is used here for consistency
-    animation: ${spin} ${spinDuration} infinite linear;
+export const CharSpan = styled.span`
+    ${props =>
+        props.$toggleColor
+            ? css`
+                  color: #eee;
+              `
+            : css`
+                  color: ${props => props.theme.main};
+              `}
+    transition: color 1.5s;
+    ${props =>
+        props.$delay &&
+        css`
+            transition-delay: ${props.$delay}s;
+        `}
 `;

--- a/src/pages/Loading/FirstConnectLoading.styled.jsx
+++ b/src/pages/Loading/FirstConnectLoading.styled.jsx
@@ -48,7 +48,7 @@ export const CharSpan = styled.span`
                   color: #eee;
               `
             : css`
-                  color: ${props => props.theme.logo};
+                  color: ${props => props.theme.main};
               `}
     transition: color 1.5s;
     ${props =>

--- a/src/pages/Loading/Splash.jsx
+++ b/src/pages/Loading/Splash.jsx
@@ -1,10 +1,8 @@
 import React, { useEffect, useState } from 'react';
-import * as S from './FirstConnectLoading.styled';
-import { useNavigate } from 'react-router-dom';
+import * as S from './Splash.styled';
 
 const FirstConnectLoading = () => {
     const text = 'Deskoration';
-    const navigate = useNavigate();
     const [isLoading, setIsLoading] = useState(true);
     const [toggleColor, setToggleColor] = useState(true);
     const lightColor = isLoading ? 'none' : '#efc265';
@@ -16,18 +14,8 @@ const FirstConnectLoading = () => {
     useEffect(() => {
         setTimeout(() => {
             setIsLoading(false);
-        }, 3000);
+        }, 2500);
     }, []);
-
-    useEffect(() => {
-        if (!isLoading) {
-            const timer = setTimeout(() => {
-                navigate('/login');
-            }, 1000);
-
-            return () => clearTimeout(timer);
-        }
-    }, [isLoading]);
 
     return (
         <S.LogoContainer>

--- a/src/pages/Loading/Splash.styled.jsx
+++ b/src/pages/Loading/Splash.styled.jsx
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components';
+import styled, { css, keyframes } from 'styled-components';
 import bgLoading from '../../assets/images/bgLoading.jpg';
 import { ReactComponent as Logo } from '../../assets/images/Loading.svg';
 
@@ -41,19 +41,15 @@ export const TitleBox = styled.h1`
     margin-top: 10px;
 `;
 
+const changeColor = keyframes`
+    from{
+        color:#eee;
+    } to{
+        color: #685c53;
+    }
+`;
+
 export const CharSpan = styled.span`
-    ${props =>
-        props.$toggleColor
-            ? css`
-                  color: #eee;
-              `
-            : css`
-                  color: ${props => props.theme.main};
-              `}
-    transition: color 1.5s;
-    ${props =>
-        props.$delay &&
-        css`
-            transition-delay: ${props.$delay}s;
-        `}
+    color: #eee;
+    animation: ${changeColor} 2s ${props => props.$delay}s forwards;
 `;

--- a/src/pages/User/User.jsx
+++ b/src/pages/User/User.jsx
@@ -1,51 +1,71 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import * as S from './User.styled';
 import Logo from '../../assets/images/Logo.svg';
 import googleLogo from '../../assets/images/login/Google.png';
 import kakaoLogo from '../../assets/images/login/Kakao.png';
 import facebookLogo from '../../assets/images/login/Facebook.png';
 import { NavLink, Outlet } from 'react-router-dom';
+import Splash from '../Loading/Splash';
 
 const User = () => {
-    return (
-        <S.UserContainer>
-            <S.UserLogo>
-                <img src={Logo} alt="데스코레이션 로고" />
-            </S.UserLogo>
+    const [isReady, setIsReady] = useState(false);
 
-            <S.UserNav>
-                <ul>
-                    <li>
-                        <NavLink to="login">로그인</NavLink>
-                    </li>
-                    <li>
-                        <NavLink to="signup">회원가입</NavLink>
-                    </li>
-                </ul>
-            </S.UserNav>
-            <S.Content>
-                <Outlet />
-            </S.Content>
-            <S.SocialLoginContainer>
-                <ul>
-                    <li>
-                        <button type="button">
-                            <img src={googleLogo} alt="구글 로그인" />
-                        </button>
-                    </li>
-                    <li>
-                        <button type="button">
-                            <img src={kakaoLogo} alt="카카오 로그인" />
-                        </button>
-                    </li>
-                    <li>
-                        <button type="button">
-                            <img src={facebookLogo} alt="페이스북 로그인" />
-                        </button>
-                    </li>
-                </ul>
-            </S.SocialLoginContainer>
-        </S.UserContainer>
+    useEffect(() => {
+        const timer = setTimeout(() => {
+            setIsReady(true);
+        }, 3500);
+
+        return () => clearTimeout(timer);
+    }, []);
+
+    return (
+        <>
+            {!isReady ? (
+                <Splash />
+            ) : (
+                <S.UserContainer>
+                    <S.UserLogo>
+                        <img src={Logo} alt="데스코레이션 로고" />
+                    </S.UserLogo>
+
+                    <S.UserNav>
+                        <ul>
+                            <li>
+                                <NavLink to="login">로그인</NavLink>
+                            </li>
+                            <li>
+                                <NavLink to="signup">회원가입</NavLink>
+                            </li>
+                        </ul>
+                    </S.UserNav>
+                    <S.Content>
+                        <Outlet />
+                    </S.Content>
+                    <S.SocialLoginContainer>
+                        <ul>
+                            <li>
+                                <button type="button">
+                                    <img src={googleLogo} alt="구글 로그인" />
+                                </button>
+                            </li>
+                            <li>
+                                <button type="button">
+                                    <img src={kakaoLogo} alt="카카오 로그인" />
+                                </button>
+                            </li>
+                            <li>
+                                <button type="button">
+                                    <img
+                                        src={facebookLogo}
+                                        alt="페이스북 로그인"
+                                    />
+                                </button>
+                            </li>
+                        </ul>
+                    </S.SocialLoginContainer>
+                </S.UserContainer>
+            )}
+        </>
     );
 };
 


### PR DESCRIPTION
## 작업사항
1. 초기 접속 시에 splash 화면을 보여준 후 로그인으로 이동
2. 로그인 후 홈화면으로 이동 시에 api를 불러오는 동안 로딩 화면을 보여준다.

### 코멘트해주세요.
- [x] splash, 홈화면 이동시 로딩 화면이 잘 나타나는지 확인해주세요.
- [x] 로딩 문구가 현재 'Deskoration'으로 되어있는데, 다른 아이디어가 있다면 말씀해주세요.
- [x] 그외 수정할 사항이 있다면 말씀해주세요!

### 기타
Article.jsx에서 api를 불러오는 함수를 Use.jsx로 옮겼습니다.