### PR TITLE
Feat/followRouter#151[팔로우 라우터 연결 및 버튼 활성화]

### DIFF
--- a/src/pages/FollowFollowingList/FollowerList.jsx
+++ b/src/pages/FollowFollowingList/FollowerList.jsx
@@ -21,23 +21,13 @@ const FollowerList = () => {
         getFollowerApi(token, myAccountName)
             .then(data => {
                 setFollowerData(data);
-                postFollowApi(token, data[0].accountname)
-                    .then(data => {
-                        setFollow(data.profile.isfollow);
-                    })
-                    .catch(error => {
-                        console.error('API 요청 중 오류 발생: ', error);
-                    });
             })
             .catch(error => {
                 console.error('API 요청 중 오류 발생: ', error);
             });
     }, []);
-    useEffect(() => {}, []);
 
     const handleFollowToggle = async accountname => {
-        setFollow(!follow);
-
         const follower = followerData.find(f => f.accountname === accountname);
         if (follower) {
             try {

--- a/src/pages/FollowFollowingList/FollowerList.styled.jsx
+++ b/src/pages/FollowFollowingList/FollowerList.styled.jsx
@@ -20,7 +20,8 @@ export const FollowerList = styled.li`
         height: 40px;
         border-radius: 50%;
         margin-right: 8px;
-        /* background-color: red; */
+        border: 1px ${({ theme }) => theme.border} solid;
+        object-fit: cover;
     }
 `;
 

--- a/src/pages/FollowFollowingList/FollowingList.styled.jsx
+++ b/src/pages/FollowFollowingList/FollowingList.styled.jsx
@@ -20,7 +20,8 @@ export const FollowingList = styled.li`
         height: 40px;
         border-radius: 50%;
         margin-right: 8px;
-        /* background-color: red; */
+        border: 1px ${({ theme }) => theme.border} solid;
+        object-fit: cover;
     }
 `;
 

--- a/src/pages/FollowFollowingList/UserFollowerList.jsx
+++ b/src/pages/FollowFollowingList/UserFollowerList.jsx
@@ -7,18 +7,20 @@ import {
     getFollowerApi,
 } from '../../service/follow_service';
 import usePageHandler from '../../hooks/usePageHandler';
-import { Link } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
 
-const FollowerList = () => {
+const UserFollowerList = () => {
     const token = sessionStorage.getItem('Token');
     const myAccountName = sessionStorage.getItem('AccountName');
+    const { username } = useParams(); //선택한 게시물 아이디 값
     const [followerData, setFollowerData] = useState([]);
     const [follow, setFollow] = useState(false);
     usePageHandler('text', '팔로워');
+    console.log(username);
 
     // 팔로워 리스트 불러오기
     useEffect(() => {
-        getFollowerApi(token, myAccountName)
+        getFollowerApi(token, username)
             .then(data => {
                 setFollowerData(data);
                 postFollowApi(token, data[0].accountname)
@@ -36,8 +38,6 @@ const FollowerList = () => {
     useEffect(() => {}, []);
 
     const handleFollowToggle = async accountname => {
-        setFollow(!follow);
-
         const follower = followerData.find(f => f.accountname === accountname);
         if (follower) {
             try {
@@ -76,15 +76,17 @@ const FollowerList = () => {
                                 <div>{data?.accountname}</div>
                             </S.FollowerInfo>
                         </Link>
-                        <GradientButton
-                            width={'80px'}
-                            onClick={() =>
-                                handleFollowToggle(data?.accountname)
-                            }
-                            gra={!data.isfollow ? true : false}
-                        >
-                            {!data.isfollow ? '팔로우' : '팔로잉'}
-                        </GradientButton>
+                        {data.accountname !== myAccountName && (
+                            <GradientButton
+                                width={'80px'}
+                                onClick={() =>
+                                    handleFollowToggle(data?.accountname)
+                                }
+                                gra={!data.isfollow ? true : false}
+                            >
+                                {!data.isfollow ? '팔로우' : '팔로잉'}
+                            </GradientButton>
+                        )}
                     </S.FollowerList>
                 ))}
             </S.FollowerContainer>
@@ -92,4 +94,4 @@ const FollowerList = () => {
     );
 };
 
-export default FollowerList;
+export default UserFollowerList;

--- a/src/pages/FollowFollowingList/UserFollowerList.jsx
+++ b/src/pages/FollowFollowingList/UserFollowerList.jsx
@@ -23,19 +23,11 @@ const UserFollowerList = () => {
         getFollowerApi(token, username)
             .then(data => {
                 setFollowerData(data);
-                postFollowApi(token, data[0].accountname)
-                    .then(data => {
-                        setFollow(data.profile.isfollow);
-                    })
-                    .catch(error => {
-                        console.error('API 요청 중 오류 발생: ', error);
-                    });
             })
             .catch(error => {
                 console.error('API 요청 중 오류 발생: ', error);
             });
     }, []);
-    useEffect(() => {}, []);
 
     const handleFollowToggle = async accountname => {
         const follower = followerData.find(f => f.accountname === accountname);

--- a/src/pages/FollowFollowingList/UserFollowingList.jsx
+++ b/src/pages/FollowFollowingList/UserFollowingList.jsx
@@ -31,7 +31,6 @@ const UserFollowingList = () => {
         };
         fetchFollowing();
     }, []);
-    console.log('following:', followingData);
 
     const handleFollowToggle = async accountname => {
         const following = followingData.find(

--- a/src/pages/FollowFollowingList/UserFollowingList.jsx
+++ b/src/pages/FollowFollowingList/UserFollowingList.jsx
@@ -7,19 +7,21 @@ import {
     deleteFollowApi,
 } from '../../service/follow_service';
 import usePageHandler from '../../hooks/usePageHandler';
-import { Link } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
 
-const FollowingList = () => {
+const UserFollowingList = () => {
     const token = sessionStorage.getItem('Token');
     const myAccountName = sessionStorage.getItem('AccountName');
+    const { username } = useParams(); //선택한 게시물 아이디 값
     const [followingData, setFollowingData] = useState([]);
     const [follow, setFollow] = useState(false);
     usePageHandler('text', '팔로잉');
+    // console.log(username);
 
     // 팔로잉 리스트 불러오기
     useEffect(() => {
         const fetchFollowing = async () => {
-            await getFollowingApi(token, myAccountName)
+            await getFollowingApi(token, username)
                 .then(data => {
                     setFollowingData(data);
                 })
@@ -29,6 +31,7 @@ const FollowingList = () => {
         };
         fetchFollowing();
     }, []);
+    console.log('following:', followingData);
 
     const handleFollowToggle = async accountname => {
         const following = followingData.find(
@@ -72,15 +75,17 @@ const FollowingList = () => {
                                 <div>{data?.accountname}</div>
                             </S.FollowingInfo>
                         </Link>
-                        <GradientButton
-                            width={'80px'}
-                            onClick={() =>
-                                handleFollowToggle(data?.accountname)
-                            }
-                            gra={!data.isfollow ? true : false}
-                        >
-                            {!data.isfollow ? '팔로우' : '팔로잉'}
-                        </GradientButton>
+                        {data.accountname !== myAccountName && (
+                            <GradientButton
+                                width={'80px'}
+                                onClick={() =>
+                                    handleFollowToggle(data?.accountname)
+                                }
+                                gra={!data.isfollow ? true : false}
+                            >
+                                {!data.isfollow ? '팔로우' : '팔로잉'}
+                            </GradientButton>
+                        )}
                     </S.FollowingList>
                 ))}
             </S.FollowingContainer>
@@ -88,4 +93,4 @@ const FollowingList = () => {
     );
 };
 
-export default FollowingList;
+export default UserFollowingList;

--- a/src/pages/Profile/UserProfile.jsx
+++ b/src/pages/Profile/UserProfile.jsx
@@ -6,6 +6,11 @@ import { getMyPostApi } from '../../service/post_service';
 import { Link, useParams } from 'react-router-dom';
 import CommonLoading from '../Loading/CommonLoading';
 import usePageHandler from '../../hooks/usePageHandler';
+import {
+    postFollowApi,
+    deleteFollowApi,
+    getFollowerApi,
+} from '../../service/follow_service';
 
 const UserProfile = () => {
     const [profileData, setProfileData] = useState(null);
@@ -13,6 +18,9 @@ const UserProfile = () => {
     const [expandedContent, setExpandedContent] = useState(false);
     const { username } = useParams(); //선택한 게시물 아이디 값
     const token = sessionStorage.getItem('Token');
+    const myAccountName = sessionStorage.getItem('AccountName');
+    const [followerData, setFollowerData] = useState([]);
+    const [follow, setFollow] = useState(false);
 
     usePageHandler('text', profileData?.username);
 
@@ -42,6 +50,28 @@ const UserProfile = () => {
 
     const toggleExpandedContent = () => {
         setExpandedContent(!expandedContent);
+    };
+
+    const userFollowToggle = async accountname => {
+        try {
+            let updatedFollow;
+            if (profileData.isfollow) {
+                const response = await deleteFollowApi(token, accountname);
+                updatedFollow = response.profile.isfollow;
+            } else {
+                const response = await postFollowApi(token, accountname);
+                updatedFollow = response.profile.isfollow;
+            }
+
+            const updatedFollowerData = {
+                ...profileData,
+                isfollow: updatedFollow,
+            };
+
+            setProfileData(updatedFollowerData);
+        } catch (error) {
+            console.error('API 요청 중 오류 발생:', error);
+        }
     };
 
     return (
@@ -74,11 +104,16 @@ const UserProfile = () => {
                 <div className="gradient_btn">
                     <GradientButton
                         type={'button'}
-                        gra={'true'}
+                        // gra={'true'}
+                        gra={!profileData.isfollow ? true : false}
                         width={'100%'}
                         padding={'10px'}
+                        onClick={() =>
+                            userFollowToggle(profileData?.accountname)
+                        }
                     >
-                        팔로우
+                        {/* 팔로우 */}
+                        {!profileData.isfollow ? '팔로우' : '팔로잉'}
                     </GradientButton>
                     <GradientButton
                         type={'button'}
@@ -94,13 +129,13 @@ const UserProfile = () => {
                         <p>{userPost?.length}</p>
                         <p>게시물</p>
                     </button>
-                    <Link to="/followerList">
+                    <Link to={`/followerList/${username}`}>
                         <button className="user-follow">
                             <p>{profileData?.followerCount}</p>
                             <p>팔로워</p>
                         </button>
                     </Link>
-                    <Link to="/followingList">
+                    <Link to={`/followingList/${username}`}>
                         <button className="user-following">
                             <p>{profileData?.followingCount}</p>
                             <p>팔로잉</p>

--- a/src/router/Router.jsx
+++ b/src/router/Router.jsx
@@ -14,6 +14,12 @@ const FollowerListPage = lazy(() =>
 const FollowingListPage = lazy(() =>
     import('../pages/FollowFollowingList/FollowingList'),
 );
+const UserFollowingListPage = lazy(() =>
+    import('../pages/FollowFollowingList/UserFollowingList'),
+);
+const UserFollowerListPage = lazy(() =>
+    import('../pages/FollowFollowingList/UserFollowerList'),
+);
 
 const PrivateRoutePage = lazy(() => import('./PrivateRoute'));
 
@@ -83,6 +89,18 @@ const Router = () => {
                                 path={'/followerList'}
                                 element={<FollowerListPage />}
                             />
+                            <Route
+                                path={'/followingList'}
+                                element={<FollowingListPage />}
+                            />
+                            <Route
+                                path={'/followerList/:username'}
+                                element={<UserFollowerListPage />}
+                            />
+                            <Route
+                                path={'/followingList/:username'}
+                                element={<UserFollowingListPage />}
+                            />
                         </Route>
                     </Route>
                     <Route element={<NoFooterLayoutPage />}>
@@ -94,14 +112,14 @@ const Router = () => {
                             path={'/profileEdit'}
                             element={<ProfileUploadPage />}
                         />
-                        <Route
+                        {/* <Route
                             path={'/followerList'}
                             element={<FollowerListPage />}
                         />
                         <Route
                             path={'/followingList'}
                             element={<FollowingListPage />}
-                        />
+                        /> */}
                         <Route
                             path={'/detailPost/:id'}
                             element={<DetailPostPage />}


### PR DESCRIPTION
## 작업사항
1. 팔로우, 팔로잉 페이지 내 계정 클릭 시 라우터 연결
2. 타 계정 프로필에서 팔로우, 팔로잉 맞춤 페이지 연결
3. 타 계정 프로필에서 팔로우 버튼 활성화

### 코멘트
- [x] 팔로우, 팔로잉 페이지 내 계정 클릭 시 계정 프로필로 이동하는지 확인해주세요.
- [x] 타 계정 프로필에서 팔로우, 팔로잉이 계정에 맞게 연결이 되는지 확인해주세요.
- [x] 타 계정 프로필에서 팔로우 버튼이 작동하는지 확인해주세요.