### PR TITLE
Refactor/responsive#214_2 [그리드 & 이미지 깨짐]

### DIFF
--- a/src/components/PostDetail/DetailPost/DetailPost.jsx
+++ b/src/components/PostDetail/DetailPost/DetailPost.jsx
@@ -60,10 +60,10 @@ const DetailPost = ({ data, commentData, token, id, setFocus }) => {
 
     return (
         <>
-            <S.DetailPostCotainer>
+            <S.DetailPostContainer>
                 <S.DetailPostMain $isBottomSheet={isPostBottomSheet}>
                     <S.ContentSection>
-                        <div className="post" style={{ position: 'relative' }}>
+                        <div>
                             <img
                                 src={postData?.image}
                                 alt="데스크 셋업 이미지"
@@ -128,7 +128,7 @@ const DetailPost = ({ data, commentData, token, id, setFocus }) => {
                     children={'신고하기'}
                     deleteFn={e => reportPost(e)}
                 />
-            </S.DetailPostCotainer>
+            </S.DetailPostContainer>
         </>
     );
 };

--- a/src/components/PostDetail/DetailPost/DetailPost.styled.jsx
+++ b/src/components/PostDetail/DetailPost/DetailPost.styled.jsx
@@ -8,9 +8,7 @@ export const Dots_verticalIcon = styled(Dots_vertical)`
     height: 24px;
 `;
 
-export const DetailPostCotainer = styled.div`
-    height: 100%;
-`;
+export const DetailPostContainer = styled.div``;
 
 // 댓글창 헤더
 export const DetailPostHeader = styled.header`
@@ -25,7 +23,6 @@ export const DetailPostHeader = styled.header`
 export const DetailPostUser = styled.div`
     display: flex;
     align-items: center;
-    /* gap: 5px; */
 
     div {
         font-weight: bold;
@@ -38,15 +35,20 @@ export const BackIcon = styled(Back)`
 `;
 
 export const DetailPostMain = styled.div`
-    /* overflow-y: ${props => !props.$isBottomSheet && 'scroll'}; */
-
     padding-bottom: 10px;
 `;
 
 export const ContentSection = styled.section`
     margin-bottom: 10px;
+
+    > div:first-child {
+        max-width: 450px;
+        margin: 0 auto;
+        position: relative;
+    }
+
     > div > img {
-        width: 100%;
+        max-width: 100%;
         margin-bottom: 10px;
         border-radius: 20px;
         border: 1px solid ${props => props.theme.border};

--- a/src/components/Splash/Splash.styled.jsx
+++ b/src/components/Splash/Splash.styled.jsx
@@ -29,7 +29,7 @@ export const LogoContainer = styled.div`
         bottom: 0;
         background-image: url(${bgLoading});
         background-repeat: no-repeat;
-        background-size: fill;
+        background-size: cover;
         background-position: 80%;
         opacity: 0.28;
     }

--- a/src/pages/Chat/ChatListPage/ChatListPage.styled.jsx
+++ b/src/pages/Chat/ChatListPage/ChatListPage.styled.jsx
@@ -57,13 +57,13 @@ export const UserChatList = styled.ul`
 `;
 
 export const UserChatRoom = styled.div`
-    /* width: 310px; */
     height: 70px;
-    /* margin: 0 25px; */
     display: flex;
     align-items: center;
 
     .user-img {
+        min-width: 50px;
+        min-height: 50px;
         width: 50px;
         height: 50px;
         border-radius: 100%;

--- a/src/pages/Feed/Feed.styled.jsx
+++ b/src/pages/Feed/Feed.styled.jsx
@@ -5,7 +5,8 @@ import { ReactComponent as Comment } from '../../assets/images/Comment.svg';
 
 export const FeedContainer = styled.article`
     display: flex;
-    width: 100%;
+    max-width: 450px;
+    margin: 0 auto;
     margin-bottom: 20px;
     flex-direction: column;
     gap: 16px;
@@ -44,8 +45,7 @@ export const FeedDetailBox = styled.div`
     gap: 10px;
 
     img {
-        max-width: 100%;
-
+        width: 100%;
         transition: transform 0.3s ease;
         &:hover {
             transform: scale(1.03);
@@ -76,10 +76,6 @@ export const MoreIcon = styled(More)`
     width: 24px;
     height: 24px;
     transform: rotate(90deg);
-    path {
-        fill: ${props => props.theme.subFont};
-        stroke: ${props => props.theme.subFont};
-    }
 `;
 
 export const LikeIcon = styled(Like)`

--- a/src/pages/Home/Article.styled.jsx
+++ b/src/pages/Home/Article.styled.jsx
@@ -4,7 +4,7 @@ import { ReactComponent as Search } from '../../assets/images/Search.svg';
 
 export const Section = styled.section`
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(145px, 1fr));
+    grid-template-columns: 1fr;
     grid-gap: 10px;
     width: 100%;
     color: ${theme.mainFont};
@@ -12,21 +12,24 @@ export const Section = styled.section`
     height: calc(100vh - 247px);
     padding: 10px 5px 10px 0;
 
+    @media screen and (min-width: 280px) {
+        grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+    }
+
     @media screen and (min-width: 768px) {
         grid-template-columns: repeat(4, 1fr);
     }
     a {
         aspect-ratio: 1/1;
+        max-width: 280px;
+        max-height: 280px;
     }
 `;
 
 export const Article = styled.article`
-    max-width: 280px;
-    max-height: 280px;
-    aspect-ratio: 1/1;
+    width: 100%;
+    height: 100%;
     background-image: url(${props => props.src});
-    /* background-image: url(${props =>
-        props.imageurl || './images/DeskSetup.jpg'}); */
     background-size: cover;
     background-position: center;
     border: 1px solid ${props => props.theme.border};

--- a/src/pages/Home/Article.styled.jsx
+++ b/src/pages/Home/Article.styled.jsx
@@ -3,21 +3,27 @@ import theme from '../../styles/theme';
 import { ReactComponent as Search } from '../../assets/images/Search.svg';
 
 export const Section = styled.section`
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
-    align-content: flex-start;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(145px, 1fr));
+    grid-gap: 10px;
     width: 100%;
-    gap: 10px;
     color: ${theme.mainFont};
     overflow-y: auto;
-    padding: 10px 0px;
     height: calc(100vh - 247px);
+    padding: 10px 5px 10px 0;
+
+    @media screen and (min-width: 768px) {
+        grid-template-columns: repeat(4, 1fr);
+    }
+    a {
+        aspect-ratio: 1/1;
+    }
 `;
 
 export const Article = styled.article`
-    width: 145px;
-    height: 145px;
+    max-width: 280px;
+    max-height: 280px;
+    aspect-ratio: 1/1;
     background-image: url(${props => props.src});
     /* background-image: url(${props =>
         props.imageurl || './images/DeskSetup.jpg'}); */

--- a/src/pages/Home/Slide.styled.jsx
+++ b/src/pages/Home/Slide.styled.jsx
@@ -2,12 +2,13 @@ import styled from 'styled-components';
 import theme from '../../styles/theme';
 
 export const SlideSection = styled.section`
-    padding-bottom: 8px;
+    width: 100%;
     display: flex;
     justify-content: space-between;
     overflow-x: auto;
     white-space: nowrap;
     gap: 15px;
+    padding-bottom: 8px;
 `;
 
 export const Category = styled.div`

--- a/src/pages/NewBoard/NewBoard.styled.jsx
+++ b/src/pages/NewBoard/NewBoard.styled.jsx
@@ -1,5 +1,4 @@
 import styled from 'styled-components';
-import GradientButton from '../../components/GradientButton/GradientButton';
 import { ReactComponent as Back } from '../../assets/images/Backward.svg';
 
 export const BackIcon = styled(Back)`
@@ -7,10 +6,8 @@ export const BackIcon = styled(Back)`
 `;
 
 export const NewBoardContainer = styled.div`
-    /* position: relative; */
-    /* padding: 0 25px; */
-    /* height: 100%;
-    overflow: auto; */
+    max-width: 450px;
+    margin: 0 auto;
 `;
 
 export const NewBoardHeader = styled.header`

--- a/src/pages/Profile/Profile.styled.jsx
+++ b/src/pages/Profile/Profile.styled.jsx
@@ -89,20 +89,29 @@ export const UserDataList = styled.div`
 
 export const UserPostings = styled.div`
     width: 100%;
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
-    gap: 10px;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(145px, 1fr));
+    grid-gap: 10px;
     margin-top: 10px;
     color: ${({ theme }) => theme.mainFont};
 
+    @media screen and (min-width: 768px) {
+        grid-template-columns: repeat(4, 1fr);
+    }
+
+    a {
+        aspect-ratio: 1/1;
+        max-width: 280px;
+        max-height: 280px;
+    }
     img {
-        width: 145px;
-        height: 145px;
+        width: 100%;
+        height: 100%;
+        aspect-ratio: 1 / 1;
         object-fit: cover;
         transition: border 0.1s ease;
         &:hover {
-            border: 3px solid ${({ theme }) => theme.main};
+            border: 3px solid ${theme.main};
         }
         border: 1px solid ${theme.border};
         border-radius: 10px;

--- a/src/pages/Profile/UserProfile.styled.jsx
+++ b/src/pages/Profile/UserProfile.styled.jsx
@@ -104,22 +104,32 @@ export const UserDataList = styled.div`
 
 export const UserPostings = styled.div`
     width: 100%;
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
-    gap: 10px;
-    margin: 20px 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(145px, 1fr));
+    grid-gap: 10px;
+    margin-top: 10px;
     color: ${({ theme }) => theme.mainFont};
 
+    @media screen and (min-width: 768px) {
+        grid-template-columns: repeat(4, 1fr);
+    }
+
+    a {
+        aspect-ratio: 1/1;
+        max-width: 280px;
+        max-height: 280px;
+    }
+
     img {
-        width: 145px;
-        height: 145px;
+        width: 100%;
+        height: 100%;
+        aspect-ratio: 1 / 1;
         object-fit: cover;
         transition: border 0.1s ease;
         &:hover {
-            border: 3px solid ${({ theme }) => theme.main};
+            border: 3px solid ${theme.main};
         }
-        border: 3px solid #fff;
+        border: 1px solid ${theme.border};
         border-radius: 10px;
     }
 `;


### PR DESCRIPTION
## 작업사항
1. 홈, 프로필에서 아티클 블록이 보이는 영역은 grid 처리
2. 게시글 등록, 게시글 상세, 피드 페이지 (게시글 이미지 전체가 보이는 페이지)에 max-width값을 설정하여 화면 크기에 따라 좌우 여백을 추가 (인스타그램 참고)
3. 채팅 목록에서 프로필 이미지가 깨지는 오류 해결
4. splash 백그라운드 이미지 위치 조정

### 코멘트
- [x] 홈, 프로필 페이지에서 화면크기에 따라 그리드가 동적으로 잘 변화하는지 봐주세요.
- [x] 위의 2번에서 적은 각 페이지에서 크기 조정이 필요하다면 말씀해주세요. 다만 max-width 값이 커질 수록 이미지가 커지기 때문에, 특히 세로 이미지의 경우는 유저가 스크롤을 더 많이 내려야 합니다.
- [x] 기타 이미지가 깨지거나 UI 변경이 필요한 부분이 있다면 꼭 말씀해주세요!!
