### PR TITLE
Feat/noContentMsg#229

### DIFF
--- a/src/components/NoContents/NoContents.jsx
+++ b/src/components/NoContents/NoContents.jsx
@@ -1,8 +1,22 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import * as S from './NoContents.styled';
 
-const NoContents = () => {
-    return <div>컨텐츠없음</div>;
+const NoContents = props => {
+    const { title, subTitle, link, btnTxt } = props;
+    return (
+        <S.NoContentsContainer>
+            <p>
+                <span>{title}</span>
+                <span>{subTitle}</span>
+            </p>
+            {!link ? null : (
+                <S.LinkBox>
+                    <Link to={link}>{btnTxt}</Link>
+                </S.LinkBox>
+            )}
+        </S.NoContentsContainer>
+    );
 };
 
 export default NoContents;

--- a/src/components/NoContents/NoContents.jsx
+++ b/src/components/NoContents/NoContents.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import * as S from './NoContents.styled';
+
+const NoContents = () => {
+    return <div>컨텐츠없음</div>;
+};
+
+export default NoContents;

--- a/src/components/NoContents/NoContents.jsx
+++ b/src/components/NoContents/NoContents.jsx
@@ -3,16 +3,16 @@ import { Link } from 'react-router-dom';
 import * as S from './NoContents.styled';
 
 const NoContents = props => {
-    const { title, subTitle, link, btnTxt } = props;
+    const { mainTxt, subTxt, link, btnLabel } = props;
     return (
         <S.NoContentsContainer>
             <p>
-                <span>{title}</span>
-                <span>{subTitle}</span>
+                <span>{mainTxt}</span>
+                <span>{subTxt}</span>
             </p>
             {!link ? null : (
                 <S.LinkBox>
-                    <Link to={link}>{btnTxt}</Link>
+                    <Link to={link}>{btnLabel}</Link>
                 </S.LinkBox>
             )}
         </S.NoContentsContainer>

--- a/src/components/NoContents/NoContents.styled.jsx
+++ b/src/components/NoContents/NoContents.styled.jsx
@@ -1,0 +1,1 @@
+import styled from 'styled-components';

--- a/src/components/NoContents/NoContents.styled.jsx
+++ b/src/components/NoContents/NoContents.styled.jsx
@@ -1,1 +1,44 @@
 import styled from 'styled-components';
+import theme from '../../styles/theme';
+import { ReactComponent as Add } from '../../assets/images/Add.svg';
+
+export const NoContentsContainer = styled.div`
+    margin-top: 10px;
+    min-height: 300px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 30px;
+
+    span {
+        display: block;
+        text-align: center;
+    }
+
+    span:first-child {
+        font-size: ${theme.fontSize.md};
+        margin-bottom: 10px;
+    }
+
+    span:nth-child(2) {
+        color: ${theme.subFont};
+    }
+`;
+
+export const LinkBox = styled.div`
+    padding: 10px;
+    border-radius: 12px;
+    color: #fff;
+    background: linear-gradient(90deg, #685c53 16.45%, #8d7358 97.1%);
+
+    &:hover {
+        outline: 2px solid ${props => props.theme.main};
+    }
+`;
+
+export const AddIcon = styled(Add)`
+    path {
+        fill: black;
+    }
+`;


### PR DESCRIPTION
## 작업사항
1. 프로필, 피드, 팔로우 등 데이터가 없는 경우 빈 페이지에 보여줄 컴포넌트 생성
![화면 캡처 2023-12-27 110442](https://github.com/FRONTENDSCHOOL7/final-14-Deskoration/assets/130200440/e5f8bf7d-0e76-48cb-9c6b-650cc9f9e97c)


### 코멘트
- [x] UI 변경이 필요하다면 말씀해주세요.
- [x] 추가할 props가 있다면 말씀해주세요.

#### 기타

현재 props는 다음과 같습니다.
```jsx
const { mainTxt, subTxt, link, btnLabel } = props; // string
```
모두 string타입으로 전달해야합니다.

- mainTxt : 데이터가 없음을 알리는 메인 문구
- subTxt : 메인 텍스트에 덧붙일 문구
- link : 하이퍼링크로 이동할 페이지의 경로
- btnLabel : 버튼에 들어갈 문구

**사용 예시**

```jsx
import NoContents from '../../components/NoContents/NoContents';

{userPost.length > 0 ? (
    <S.UserPostings>
        {userPost?.map((post, index) => (
            <Link key={post.id} to={`/detailPost/${post.id}`}>
                <img src={post.image} alt="게시물 목록" />
            </Link>
        ))}
    </S.UserPostings>
) : (
    <NoContents
        mainTxt={'아직 등록한 게시글이 없습니다!'}
        subTxt={'첫 번째 사진을 공유해보세요'}
        link={'/postUpload'}
        btnLabel={'게시글 작성하기'}
    />
)}
```
