### PR TITLE
Fix/signupError#257

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -11,7 +11,7 @@ const Header = () => {
     const handleGoBack = () => {
         navigate(-1);
     };
-
+    const editPage = location.pathname.includes('/profileEdit');
     const queryClient = useQueryClient();
     const myProfileData = queryClient.getQueryData(['getMyProfile']);
     const myProfileAccountName = myProfileData?.user?.accountname;
@@ -21,7 +21,7 @@ const Header = () => {
         queryKey: ['getMyProfile'],
         queryFn: () => getMyProfileAPI(),
         select: data => data.user.accountname,
-        enabled: !myProfileData,
+        enabled: editPage && !myProfileData,
     });
 
     const myAccountName = myProfileAccountName || profileDataAccountName;

--- a/src/pages/Profile/ProfileUpload.jsx
+++ b/src/pages/Profile/ProfileUpload.jsx
@@ -36,19 +36,13 @@ export const ProfileUpload = () => {
     // editProfile
     const editPage = location.pathname.includes('/profileEdit');
     // 프로필 수정하기를 위한 데이터
-    const [myProfileData, setMyProfileData] = useState([]);
+    const myProfileData =
+        editPage && queryClient.getQueryData(['getMyProfile']);
 
     const [imageURL, setImageURL] = useState(basicImg);
     const [isImageAdded, setIsImageAdded] = useState(false);
     const [imageFile, setImageFile] = useState('');
     const { emailValue, passwordValue } = useLocation().state || {};
-
-    // 프로필 편집일 경우, 프로필 데이터 가져오기
-    useEffect(() => {
-        if (editPage) {
-            setMyProfileData(queryClient.getQueryData(['getMyProfile']));
-        }
-    }, [editPage, queryClient]);
 
     const {
         register,

--- a/src/pages/Profile/ProfileUpload.jsx
+++ b/src/pages/Profile/ProfileUpload.jsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 import { useForm } from 'react-hook-form';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-
+import axiosInstance from '../../service/axiosInstance';
 import {
     authLoginAPI,
     authSignUpAPI,
@@ -27,24 +27,28 @@ import basicImg from '../../assets/images/basicImg.png';
 export const ProfileUpload = () => {
     // 헤더에 문구 넣기
     usePageHandler('text', '프로필 설정');
-
     const noImage = '/Ellipse.png';
-
     const queryClient = useQueryClient();
-    // 프로필 수정하기를 위한 데이터
-    const myProfileData = queryClient.getQueryData(['getMyProfile']);
-
     const navigate = useNavigate();
     const location = useLocation();
     const dispatch = useDispatch();
 
     // editProfile
     const editPage = location.pathname.includes('/profileEdit');
+    // 프로필 수정하기를 위한 데이터
+    const [myProfileData, setMyProfileData] = useState([]);
 
     const [imageURL, setImageURL] = useState(basicImg);
     const [isImageAdded, setIsImageAdded] = useState(false);
     const [imageFile, setImageFile] = useState('');
     const { emailValue, passwordValue } = useLocation().state || {};
+
+    // 프로필 편집일 경우, 프로필 데이터 가져오기
+    useEffect(() => {
+        if (editPage) {
+            setMyProfileData(queryClient.getQueryData(['getMyProfile']));
+        }
+    }, [editPage, queryClient]);
 
     const {
         register,
@@ -66,8 +70,9 @@ export const ProfileUpload = () => {
         setFocus('userName');
     }, [setFocus]);
 
+    // 프로필 편집 시에 불러온 데이터를 화면에 렌더링
     useEffect(() => {
-        if (myProfileData) {
+        if (editPage && myProfileData) {
             const userData = myProfileData.user;
             setImageURL(userData.image);
             if (process.env.REACT_APP_BASE_URL + noImage !== userData.image) {
@@ -79,14 +84,14 @@ export const ProfileUpload = () => {
             setValue('userID', userData.accountname);
             setValue('intro', userData.intro);
         }
-    }, [myProfileData, setValue]);
+    }, [editPage, myProfileData, setValue]);
 
-    // 프로필 데이터가 시간초과로 사라진 경우
+    // 프로필 편집 & 프로필 데이터가 시간초과로 사라진 경우
     useEffect(() => {
-        if (!myProfileData) {
+        if (editPage && !myProfileData) {
             dispatch(openAlertModal('잠시 후 다시 시도해주세요.'));
         }
-    }, [dispatch, myProfileData, navigate]);
+    }, [dispatch, editPage, myProfileData, navigate]);
 
     //계정 ID 검사
     const validateUserID = id => {
@@ -111,8 +116,11 @@ export const ProfileUpload = () => {
         mutationFn: ({ emailValue, passwordValue }) =>
             authLoginAPI(emailValue, passwordValue),
         onSuccess: data => {
-            // 토큰 외에 저장 금지 아마도?
             sessionStorage.setItem('Token', data.user.token);
+            axiosInstance.defaults.headers = {
+                ...axiosInstance.defaults.headers,
+                Authorization: `Bearer ${data.user.token}`,
+            };
             navigate('/home');
         },
     });


### PR DESCRIPTION
## 작업사항
1. 
- 문제 : 회원가입 시에 profileUpload와 header에서 profile API 요청을 반복적으로 실행. 회원가입시에는 프로필 정보가 없으므로 get요청을 하지 말아야함.
- 원인 : 프로필 편집인지, 초기 프로필 설정인지에 대한 조건이 누락
- 해결 : editPage라는 조건을 추가해서 회원가입 시에는 API 요청을 하지 않도록 수정

2.
- 문제 : 회원가입 성공 후에 홈으로 이동했을 때, api 요청이 계속 실패 (unAuthorized)
- 원인 : axiosInstance에 토큰을 설정해주는 코드 누락
- 해결 : LoginMutation onSuccess 시에 토큰을 설정해주도록 코드 추가 

### 코멘트
- [x] 회원가입 시에 프로필 페이지에서 profile api를 요청하지 않고 정상작동 하는지 확인해주세요.
- [x] 회원가입 성공 후 홈으로 이동 시에 데이터를 잘 받아오는지 확인해주세요.
