### PR TITLE
Fix/propfileImgError#260

### DIFF
--- a/src/pages/Profile/ProfileUpload.jsx
+++ b/src/pages/Profile/ProfileUpload.jsx
@@ -178,8 +178,8 @@ export const ProfileUpload = () => {
                     accountname: profileData.userID,
                     intro: profileData.intro,
                     image: !imageFile
-                        ? process.env.REACT_APP_BASE_URL + noImage
-                        : process.env.REACT_APP_BASE_URL + imageFile,
+                        ? process.env.REACT_APP_BASE_URL + '/' + noImage
+                        : process.env.REACT_APP_BASE_URL + '/' + imageFile,
                 },
             };
             signUpMutation.mutate(userData);
@@ -193,7 +193,7 @@ export const ProfileUpload = () => {
                     intro: profileData.intro,
                     image:
                         !imageFile && imageURL === basicImg
-                            ? process.env.REACT_APP_BASE_URL + noImage
+                            ? process.env.REACT_APP_BASE_URL + '/' + noImage
                             : !imageFile && imageURL
                             ? myProfileData.user.image
                             : process.env.REACT_APP_BASE_URL + '/' + imageFile,


### PR DESCRIPTION
## 작업사항
1. 회원가입 시 설정한 이미지가 로그인 후 프로필 페이지 및 헤더에서 보이지 않는 이슈 해결
(base url 변경으로 주소에 '/ '추가)

### 코멘트
- [x] 회원가입 후 프로필 이미지가 잘 보이는지 확인해주세요. 
